### PR TITLE
Adding new rollback task and documentation

### DIFF
--- a/docs/pyez_rollback.rst
+++ b/docs/pyez_rollback.rst
@@ -1,7 +1,7 @@
 pyez_rollback
 ===========
 
-Use this task to rollback a pending config in the candidate datastore and unlock for next config.
+Use this task to rollback to a previous configuration or delete a pending config in the candidate datastore and unlock for next config.
 
 Example::
 
@@ -16,7 +16,8 @@ Example::
     nr = InitNornir(config_file=f"{script_dir}/config.yml")
 
     response = nr.run(
-        task=pyez_rollback
+        task=pyez_rollback,
+        rollback_number=2
     )
 
     print_result(response)

--- a/docs/pyez_rollback.rst
+++ b/docs/pyez_rollback.rst
@@ -1,0 +1,22 @@
+pyez_rollback
+===========
+
+Use this task to rollback a pending config in the candidate datastore and unlock for next config.
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_rollback
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+    response = nr.run(
+        task=pyez_rollback
+    )
+
+    print_result(response)

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -13,6 +13,7 @@ Here you will find a list of available methods and their corresponding documenta
    pyez_config
    pyez_diff
    pyez_commit
+   pyez_rollback
    pyez_rpc
    pyez_sec_ike
    pyez_sec_ipsec

--- a/nornir_pyez/plugins/tasks/__init__.py
+++ b/nornir_pyez/plugins/tasks/__init__.py
@@ -5,6 +5,7 @@ from .pyez_commit import pyez_commit
 from .pyez_diff import pyez_diff
 from .pyez_int_terse import pyez_int_terse
 from .pyez_route_info import pyez_route_info
+from .pyez_rollback import pyez_rollback
 from .pyez_rpc import pyez_rpc
 from .pyez_sec_nat import pyez_sec_nat_dest, pyez_sec_nat_src
 from .pyez_sec_policy import pyez_sec_policy
@@ -18,6 +19,7 @@ __all__ = (
     "pyez_diff",
     "pyez_commit",
     "pyez_int_terse",
+    "pyez_rollback",
     "pyez_route_info",
     "pyez_rpc",
     "pyez_sec_ike",

--- a/nornir_pyez/plugins/tasks/pyez_rollback.py
+++ b/nornir_pyez/plugins/tasks/pyez_rollback.py
@@ -6,11 +6,15 @@ from nornir.core.task import Result, Task
 from nornir_pyez.plugins.connections import CONNECTION_NAME
 
 
-def pyez_rollback(task: Task,
-                ) -> Result:
+def pyez_rollback(task: Task, rollback_number: int = None) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300
     config = Config(device)
-    config.rollback()
+    config.rollback(rollback_number)
     config.unlock()
-    return Result(host=task.host, result=f"Successfully rollbacked")
+    return Result(
+        host=task.host,
+        result="Successfully emptied config DB"
+        if rollback_number == 0 or rollback_number == None
+        else f"Successfully rollbacked by {rollback_number}",
+    )

--- a/nornir_pyez/plugins/tasks/pyez_rollback.py
+++ b/nornir_pyez/plugins/tasks/pyez_rollback.py
@@ -1,0 +1,16 @@
+import copy
+from typing import Any, Dict, List, Optional
+from jnpr.junos.utils.config import Config
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+
+def pyez_rollback(task: Task,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    config = Config(device)
+    config.rollback()
+    config.unlock()
+    return Result(host=task.host, result=f"Successfully rollbacked")

--- a/nornir_pyez/plugins/tasks/pyez_rollback.py
+++ b/nornir_pyez/plugins/tasks/pyez_rollback.py
@@ -6,7 +6,7 @@ from nornir.core.task import Result, Task
 from nornir_pyez.plugins.connections import CONNECTION_NAME
 
 
-def pyez_rollback(task: Task, rollback_number: int = None) -> Result:
+def pyez_rollback(task: Task, rollback_number: int = 0) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300
     config = Config(device)
@@ -15,6 +15,6 @@ def pyez_rollback(task: Task, rollback_number: int = None) -> Result:
     return Result(
         host=task.host,
         result="Successfully emptied config DB"
-        if rollback_number == 0 or rollback_number == None
-        else f"Successfully rollbacked by {rollback_number}",
+        if rollback_number == 0
+        else f"Successfully rollbacked {rollback_number} commit/s",
     )


### PR DESCRIPTION
Hello there,

First thank you for your work on this project it is very helpful to me!

I am working on a script to automate configuration deployment on Juniper devices.

In my script I need to execute a first pyez_config task (without commit_now), a second pyez_diff to check if there is changes and then a pyez_commit.
But if there is no changes, the config stays pending and when another task try to load config, it crashes with the message "Can not access the database, aborting request".
I could have committed the empty changes but it makes the script really slow.

So I wanted to just do a rollback but the task wasn't existing. I tried to send a payload "rollback" with pyez_config but same error.
Instead of reporting an issue, I tried to fix this by myself. So I quickly added a pyez_rollback task.

And now it is working on my side. 
So I am submitting this Pull Request so this new feature can be helpful for others.

Do not hesitate to challenge me if I missed some changes to this new feature or if you don't consider it as usefull.

Be careful if you execute this task without pending changes you will have an error "Configuration database is not open".
Do I need to handle this, please?

Thanks and have a lovely week-end! 

geg347