### PR TITLE
Add scp cmd tasks

### DIFF
--- a/docs/pyez_cmd.rst
+++ b/docs/pyez_cmd.rst
@@ -1,0 +1,31 @@
+pyez_cmd
+===========
+
+Use this task to execute single command on your devices.
+You can just display the whole result or parse it.
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_scp
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    command = "show system information"
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+   response = task.run(
+        task=pyez_cmd,
+        command=command
+    )
+
+    # Print the whole result
+    print_result(response)
+
+    # Or parse it (and do whatever you want)
+    for key in response.keys():
+        result = response[key][1].result

--- a/docs/pyez_commit.rst
+++ b/docs/pyez_commit.rst
@@ -1,7 +1,7 @@
 pyez_commit
 ===========
 
-Use this task to commit the candidate datastore to the committed datastore. Note this performs a commit check first and performs a Rollback upon failure
+Use this task to commit the candidate datastore to the committed datastore. You can add an optionnal comment. Note this performs a commit check first and performs a Rollback upon failure
 
 Example::
 
@@ -16,7 +16,7 @@ Example::
     nr = InitNornir(config_file=f"{script_dir}/config.yml")
 
     response = nr.run(
-        task=pyez_commit
+        task=pyez_commit, comment="Your comment"
     )
 
     print_result(response)

--- a/docs/pyez_rollback.rst
+++ b/docs/pyez_rollback.rst
@@ -1,0 +1,22 @@
+pyez_rollback
+===========
+
+Use this task to rollback a pending config in the candidate datastore and unlock for next config.
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_rollback
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+    response = nr.run(
+        task=pyez_rollback
+    )
+
+    print_result(response)

--- a/docs/pyez_scp.rst
+++ b/docs/pyez_scp.rst
@@ -1,0 +1,26 @@
+pyez_scp
+===========
+
+Use this task to scp files on your devices (unfortunately there is no way 
+to check if the copy was successfull or not, you will have to check manually)
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_scp
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    filename = "<your_filename>"
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+    response = task.run(
+        task=pyez_scp,
+        file=f"{script_dir}./files/{filename}",
+        path=path,
+    )
+
+    print_result(response)

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -13,6 +13,7 @@ Here you will find a list of available methods and their corresponding documenta
    pyez_config
    pyez_diff
    pyez_commit
+   pyez_rollback
    pyez_rpc
    pyez_sec_ike
    pyez_sec_ipsec

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -10,11 +10,13 @@ Here you will find a list of available methods and their corresponding documenta
    pyez_get_config
    pyez_int_terse
    pyez_route_info
+   pyez_cmd
    pyez_config
    pyez_diff
    pyez_commit
    pyez_rollback
    pyez_rpc
+   pyez_scp
    pyez_sec_ike
    pyez_sec_ipsec
    pyez_sec_nat_dest

--- a/nornir_pyez/plugins/tasks/__init__.py
+++ b/nornir_pyez/plugins/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .pyez_facts import pyez_facts
+from .pyez_cmd import pyez_cmd
 from .pyez_config import pyez_config
 from .pyez_get_config import pyez_get_config
 from .pyez_commit import pyez_commit
@@ -7,6 +8,7 @@ from .pyez_int_terse import pyez_int_terse
 from .pyez_route_info import pyez_route_info
 from .pyez_rollback import pyez_rollback
 from .pyez_rpc import pyez_rpc
+from .pyez_scp import pyez_scp
 from .pyez_sec_nat import pyez_sec_nat_dest, pyez_sec_nat_src
 from .pyez_sec_policy import pyez_sec_policy
 from .pyez_sec_vpn import pyez_sec_ike, pyez_sec_ipsec
@@ -14,6 +16,7 @@ from .pyez_sec_zones import pyez_sec_zones
 
 __all__ = (
     "pyez_facts",
+    "pyez_cmd",
     "pyez_config",
     "pyez_get_config",
     "pyez_diff",
@@ -22,6 +25,7 @@ __all__ = (
     "pyez_rollback",
     "pyez_route_info",
     "pyez_rpc",
+    "pyez_scp",
     "pyez_sec_ike",
     "pyez_sec_ipsec",
     "pyez_sec_nat_dest",

--- a/nornir_pyez/plugins/tasks/__init__.py
+++ b/nornir_pyez/plugins/tasks/__init__.py
@@ -5,6 +5,7 @@ from .pyez_commit import pyez_commit
 from .pyez_diff import pyez_diff
 from .pyez_int_terse import pyez_int_terse
 from .pyez_route_info import pyez_route_info
+from .pyez_rollback import pyez_rollback
 from .pyez_rpc import pyez_rpc
 from .pyez_sec_nat import pyez_sec_nat_dest, pyez_sec_nat_src
 from .pyez_sec_policy import pyez_sec_policy
@@ -18,6 +19,7 @@ __all__ = (
     "pyez_diff",
     "pyez_commit",
     "pyez_int_terse",
+    "pyez_rollback",
     "pyez_route_info",
     "pyez_rpc",
     "pyez_sec_ike",

--- a/nornir_pyez/plugins/tasks/pyez_cmd.py
+++ b/nornir_pyez/plugins/tasks/pyez_cmd.py
@@ -1,0 +1,13 @@
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+from jnpr.junos.utils.start_shell import StartShell
+
+def pyez_cmd(task: Task, command: str,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    with StartShell(device) as sh:
+        got = sh.run(command)
+    return Result(host=task.host, result=f"Command launched, output: {got}")

--- a/nornir_pyez/plugins/tasks/pyez_commit.py
+++ b/nornir_pyez/plugins/tasks/pyez_commit.py
@@ -6,13 +6,13 @@ from nornir.core.task import Result, Task
 from nornir_pyez.plugins.connections import CONNECTION_NAME
 
 
-def pyez_commit(task: Task,
+def pyez_commit(task: Task, comment: str=None
                 ) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300
     config = Config(device)
     if config.commit_check() == True:
-        config.commit()
+        config.commit(comment=comment)
     else:
         config.rollback()
     config.unlock()

--- a/nornir_pyez/plugins/tasks/pyez_rollback.py
+++ b/nornir_pyez/plugins/tasks/pyez_rollback.py
@@ -1,0 +1,16 @@
+import copy
+from typing import Any, Dict, List, Optional
+from jnpr.junos.utils.config import Config
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+
+def pyez_rollback(task: Task,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    config = Config(device)
+    config.rollback()
+    config.unlock()
+    return Result(host=task.host, result=f"Successfully rollbacked")

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -1,0 +1,13 @@
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+from jnpr.junos.utils.scp import SCP
+
+def pyez_scp(task: Task, file: str, path: str,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    with SCP(device, progress=True) as scp:
+        print(scp.put(file, path))
+    return Result(host=task.host, result=f"Successfully copied")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = "^3.6"
 junos-eznc = "^2.5"
-nornir = { version = "~3.0.0b1", allow-prereleases = true }
+nornir = { version = "^3.0.0", allow-prereleases = true }
 xmltodict = "0.12.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Hello,

So another PR to add the possibility of copying file with SCP to Juniper devices (the progress is showed every 10% but for small files you may have no output so you need to check if the file was copied).
The default destination path is /var/tmp but you can override it.

I also added the possibility to execute command on devices (but be careful here it is command from the shell and not Junos CLI, to try the command locally you need to type "start shell" in Junos CLI). The result also is quite difficult to parse : the command is concatenated with the output.
And worse I do not check the command input so you can enter whatever you want but I did not found an easy way of allowing all the needed commands and blocking unwanted behaviour or command injection. So I left it like this...

Have a nice week-end.
geg347