### PR TITLE
Add scp cmd tasks

### DIFF
--- a/docs/pyez_cmd.rst
+++ b/docs/pyez_cmd.rst
@@ -1,0 +1,31 @@
+pyez_cmd
+===========
+
+Use this task to execute single command on your devices.
+You can just display the whole result or parse it.
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_scp
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+
+    command = "show system information"
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+   response = task.run(
+        task=pyez_cmd,
+        command=command
+    )
+
+    # Print the whole result
+    print_result(response)
+
+    # Or parse it (and do whatever you want)
+    for key in response.keys():
+        result = response[key][1].result

--- a/docs/pyez_scp.rst
+++ b/docs/pyez_scp.rst
@@ -1,0 +1,26 @@
+pyez_scp
+===========
+
+Use this task to scp files on your devices (unfortunately there is no way 
+to check if the copy was successfull or not, you will have to check manually)
+
+Example::
+
+    from nornir_pyez.plugins.tasks import pyez_scp
+    import os
+    from nornir import InitNornir
+    from nornir_utils.plugins.functions import print_result
+    from rich import print
+
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    filename = "<your_filename>"
+
+    nr = InitNornir(config_file=f"{script_dir}/config.yml")
+
+    response = task.run(
+        task=pyez_scp,
+        file=f"{script_dir}./files/{filename}",
+        path=path,
+    )
+
+    print_result(response)

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -8,12 +8,14 @@ Here you will find a list of available methods and their corresponding documenta
 
    pyez_facts
    pyez_get_config
+   pyez_cmd
    pyez_int_terse
    pyez_route_info
    pyez_config
    pyez_diff
    pyez_commit
    pyez_rpc
+   pyez_scp
    pyez_sec_ike
    pyez_sec_ipsec
    pyez_sec_nat_dest

--- a/nornir_pyez/plugins/tasks/__init__.py
+++ b/nornir_pyez/plugins/tasks/__init__.py
@@ -1,4 +1,5 @@
 from .pyez_facts import pyez_facts
+from .pyez_cmd import pyez_cmd
 from .pyez_config import pyez_config
 from .pyez_get_config import pyez_get_config
 from .pyez_commit import pyez_commit
@@ -6,6 +7,7 @@ from .pyez_diff import pyez_diff
 from .pyez_int_terse import pyez_int_terse
 from .pyez_route_info import pyez_route_info
 from .pyez_rpc import pyez_rpc
+from .pyez_scp import pyez_scp
 from .pyez_sec_nat import pyez_sec_nat_dest, pyez_sec_nat_src
 from .pyez_sec_policy import pyez_sec_policy
 from .pyez_sec_vpn import pyez_sec_ike, pyez_sec_ipsec
@@ -13,6 +15,7 @@ from .pyez_sec_zones import pyez_sec_zones
 
 __all__ = (
     "pyez_facts",
+    "pyez_cmd",
     "pyez_config",
     "pyez_get_config",
     "pyez_diff",
@@ -20,6 +23,7 @@ __all__ = (
     "pyez_int_terse",
     "pyez_route_info",
     "pyez_rpc",
+    "pyez_scp",
     "pyez_sec_ike",
     "pyez_sec_ipsec",
     "pyez_sec_nat_dest",

--- a/nornir_pyez/plugins/tasks/pyez_cmd.py
+++ b/nornir_pyez/plugins/tasks/pyez_cmd.py
@@ -1,0 +1,13 @@
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+from jnpr.junos.utils.start_shell import StartShell
+
+def pyez_cmd(task: Task, command: str,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    with StartShell(device) as sh:
+        got = sh.run(command)
+    return Result(host=task.host, result=f"Command launched, output: {got}")

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -1,13 +1,18 @@
 from nornir.core.task import Result, Task
 
 from nornir_pyez.plugins.connections import CONNECTION_NAME
-
+from typing import Dict
 from jnpr.junos.utils.scp import SCP
 
-def pyez_scp(task: Task, file: str, path: str,
-                ) -> Result:
+
+def pyez_scp(
+    task: Task,
+    file: str,
+    path: str,
+    scpargs: Dict = {"Progress": True},
+) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300
-    with SCP(device, progress=True) as scp:
+    with SCP(device, **scpargs) as scp:
         print(scp.put(file, path))
     return Result(host=task.host, result=f"Successfully copied")

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -9,7 +9,7 @@ def pyez_scp(
     task: Task,
     file: str,
     path: str,
-    scpargs: Dict = {"Progress": True},
+    scpargs: Dict = {"progress": True},
 ) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -1,0 +1,13 @@
+from nornir.core.task import Result, Task
+
+from nornir_pyez.plugins.connections import CONNECTION_NAME
+
+from jnpr.junos.utils.scp import SCP
+
+def pyez_scp(task: Task, file: str, path: str,
+                ) -> Result:
+    device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+    device.timeout = 300
+    with SCP(device, progress=True) as scp:
+        print(scp.put(file, path))
+    return Result(host=task.host, result=f"Successfully copied")


### PR DESCRIPTION
Hello,

So another PR to add the possibility of copying file with SCP to Juniper devices (the progress is showed every 10% but for small files you may have no output so you need to check if the file was copied).
The default destination path is /var/tmp but you can override it.

I also added the possibility to execute command on devices (but be careful here it is command from the shell and not Junos CLI, to try the command locally you need to type "start shell" in Junos CLI). The result also is quite difficult to parse : the command is concatenated with the output.
And worse I do not check the command input so you can enter whatever you want but I did not found an easy way of allowing all the needed commands and blocking unwanted behaviour or command injection. So I left it like this...

Have a nice week-end.
geg347
