### PR TITLE
Adding optionnal comment for the task pyez_commit

### DIFF
--- a/docs/pyez_commit.rst
+++ b/docs/pyez_commit.rst
@@ -1,7 +1,7 @@
 pyez_commit
 ===========
 
-Use this task to commit the candidate datastore to the committed datastore. Note this performs a commit check first and performs a Rollback upon failure
+Use this task to commit the candidate datastore to the committed datastore. You can add an optionnal comment. Note this performs a commit check first and performs a Rollback upon failure
 
 Example::
 
@@ -16,7 +16,7 @@ Example::
     nr = InitNornir(config_file=f"{script_dir}/config.yml")
 
     response = nr.run(
-        task=pyez_commit
+        task=pyez_commit, comment="Your comment"
     )
 
     print_result(response)

--- a/nornir_pyez/plugins/tasks/pyez_commit.py
+++ b/nornir_pyez/plugins/tasks/pyez_commit.py
@@ -6,13 +6,13 @@ from nornir.core.task import Result, Task
 from nornir_pyez.plugins.connections import CONNECTION_NAME
 
 
-def pyez_commit(task: Task,
+def pyez_commit(task: Task, comment: str=None
                 ) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     device.timeout = 300
     config = Config(device)
     if config.commit_check() == True:
-        config.commit()
+        config.commit(comment=comment)
     else:
         config.rollback()
     config.unlock()


### PR DESCRIPTION
Hello there,

Again thanks for your job on this project.

I added the possibility to add a comment when executing a pyez_commit task.
You can still call the task without specifying any comment though. So it won't break anything.

I hope you will find it useful and accept this Pull Request.
Do not hesitate to challenge me if you need.

Thanks and have a nice day!

geg347
