### PR TITLE
Adding flag to handle several calls of pyez_config

### DIFF
--- a/docs/pyez_config.rst
+++ b/docs/pyez_config.rst
@@ -44,19 +44,19 @@ An XML payload example::
 
 Note JSON is also a valid payload with data_format='json' set
 
-3. If you want to load several configuration files, you will need to the stage counter. This counter solve the problem of the lock on the Junos OS database when loading configuration.
-In your code you will need to initialize this counter and to increment it in your for loop (or manually set it at other than 0 in your next pyez_config calls).
+3. If you want to load several configuration files, you will need to use the first_loading flag. This flag solve the problem of the lock on the Junos OS database when loading configuration.
+In your code you will need to set this flag as False at your second and more calls of the pyez_config task.
 
-    i = 0
+    first_loading = True
     for conf_file in conf_files:
         
         config_response = task.run(
             task=pyez_config,
             template_path=conf_file,
             template_vars={},
-            stage=i,
+            first_loading=first_loading,
         )
-        i=i+1
+        first_loading = False
 
 4. Next you need to decide if you want to commit the changes now, or create a new task to view the diff
 

--- a/docs/pyez_config.rst
+++ b/docs/pyez_config.rst
@@ -44,7 +44,21 @@ An XML payload example::
 
 Note JSON is also a valid payload with data_format='json' set
 
-3. Next you need to decide if you want to commit the changes now, or create a new task to view the diff
+3. If you want to load several configuration files, you will need to the stage counter. This counter solve the problem of the lock on the Junos OS database when loading configuration.
+In your code you will need to initialize this counter and to increment it in your for loop (or manually set it at other than 0 in your next pyez_config calls).
+
+    i = 0
+    for conf_file in conf_files:
+        
+        config_response = task.run(
+            task=pyez_config,
+            template_path=conf_file,
+            template_vars={},
+            stage=i,
+        )
+        i=i+1
+
+4. Next you need to decide if you want to commit the changes now, or create a new task to view the diff
 
 Example of NO commit now::
 

--- a/nornir_pyez/plugins/tasks/pyez_config.py
+++ b/nornir_pyez/plugins/tasks/pyez_config.py
@@ -14,12 +14,12 @@ def pyez_config(
     template_path: str = None,
     template_vars: str = None,
     commit_now: bool = False,
-    stage: int = 0
+    first_loading: bool = True
 ) -> Result:
 
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     config = Config(device)
-    if stage == 0:
+    if first_loading:
         config.lock()
     if template_path:
         config.load(template_path=template_path,

--- a/nornir_pyez/plugins/tasks/pyez_config.py
+++ b/nornir_pyez/plugins/tasks/pyez_config.py
@@ -13,12 +13,14 @@ def pyez_config(
     data_format: str = 'text',
     template_path: str = None,
     template_vars: str = None,
-    commit_now: bool = False
+    commit_now: bool = False,
+    stage: int = 0
 ) -> Result:
 
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
     config = Config(device)
-    config.lock()
+    if stage == 0:
+        config.lock()
     if template_path:
         config.load(template_path=template_path,
                     template_vars=template_vars, format=data_format)


### PR DESCRIPTION
Hello there,

Here I am adding an optional parameter to the pyez_config function in order to handle several configuration's loadings.

This stage counter is set to 0 when the first configuration file is loaded so it can take the lock on the Junos OS database.
But until now if you tried to load a second configuration file, it tries to take the lock again and crashes.

So if you increment this stage counter the lock will not be taken and you can load as many configuration file as you need.

I explain more in detail and show an example in the documentation