### PR TITLE
Fix for empty rpc reply

### DIFF
--- a/nornir_pyez/plugins/tasks/pyez_rpc.py
+++ b/nornir_pyez/plugins/tasks/pyez_rpc.py
@@ -19,7 +19,11 @@ def pyez_rpc(
         data = function(**extras)
     else:
         data = function()
-    data = etree.tostring(data, encoding='unicode', pretty_print=True)
+    if isinstance(bool, data):
+        data = f'''<nornir_pyez_notification>This is a known error for some RPC, this RPC request didn't return a well 
+        formed XML message, but: {data}</nornir_pyez_notification>'''
+    else:
+        data = etree.tostring(data, encoding='unicode', pretty_print=True)
     parsed = xmltodict.parse(data)
     clean_parse = json.loads(json.dumps(parsed))
     return Result(host=task.host, result=clean_parse)


### PR DESCRIPTION
This PR fixes the issue present when executing rpc functions that doesn't give any xml output (like "clear security pki certificate-request", tested on QFX10002-36q with 20.4R3) by sending as result a general message