### PR TITLE
Fixing wrong arguments order in instanceof's function in pyez_rpc task

### DIFF
--- a/nornir_pyez/plugins/tasks/pyez_rpc.py
+++ b/nornir_pyez/plugins/tasks/pyez_rpc.py
@@ -19,7 +19,7 @@ def pyez_rpc(
         data = function(**extras)
     else:
         data = function()
-    if isinstance(bool, data):
+    if isinstance(data, bool):
         data = f'''<nornir_pyez_notification>This is a known error for some RPC, this RPC request didn't return a well 
         formed XML message, but: {data}</nornir_pyez_notification>'''
     else:


### PR DESCRIPTION
Hello,
After trying some scripts I got a weird error.
After investigations I found it and it is the order of the argument in the isinstance function in pyez_rpc task.
I fixed it and I am publishing a new release right now.

So unfortunately we need to consider release 0.2.6 as buggy.