### PR TITLE
Added get option to pyez_scp plugin

### DIFF
--- a/docs/pyez_scp.rst
+++ b/docs/pyez_scp.rst
@@ -1,8 +1,8 @@
 pyez_scp
 ===========
 
-Use this task to scp files onto or from your devices (unfortunately there is no way 
-to check if the copy was successfull or not, you will have to check manually)
+Use this task to scp files onto or from your devices. Default's to PUT operation i.e. send local file to the device (unfortunately there is no way 
+to check if the copy was successful or not, you will have to check manually)
 
 Example::
 
@@ -13,6 +13,7 @@ Example::
 
     script_dir = os.path.dirname(os.path.realpath(__file__))
     filename = "<your_filename>"
+    # Default is put if argument is omitted
     direction = "<get_or_put>"
 
     nr = InitNornir(config_file=f"{script_dir}/config.yml")

--- a/docs/pyez_scp.rst
+++ b/docs/pyez_scp.rst
@@ -1,7 +1,7 @@
 pyez_scp
 ===========
 
-Use this task to scp files on your devices (unfortunately there is no way 
+Use this task to scp files onto or from your devices (unfortunately there is no way 
 to check if the copy was successfull or not, you will have to check manually)
 
 Example::
@@ -10,15 +10,16 @@ Example::
     import os
     from nornir import InitNornir
     from nornir_utils.plugins.functions import print_result
-    from rich import print
 
     script_dir = os.path.dirname(os.path.realpath(__file__))
     filename = "<your_filename>"
+    direction = "<get_or_put>"
 
     nr = InitNornir(config_file=f"{script_dir}/config.yml")
 
     response = task.run(
         task=pyez_scp,
+        direction=direction,
         file=f"{script_dir}./files/{filename}",
         path=path,
     )

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -7,10 +7,10 @@ from jnpr.junos.utils.scp import SCP
 
 def pyez_scp(
     task: Task,
-    direction: str = "put",
     file: str,
     path: str,
     scpargs: Dict = {"progress": True},
+    direction: str = "put",
 ) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
 

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -7,7 +7,7 @@ from jnpr.junos.utils.scp import SCP
 
 def pyez_scp(
     task: Task,
-    direction: str,
+    direction: str = "put",
     file: str,
     path: str,
     scpargs: Dict = {"progress": True},

--- a/nornir_pyez/plugins/tasks/pyez_scp.py
+++ b/nornir_pyez/plugins/tasks/pyez_scp.py
@@ -7,11 +7,23 @@ from jnpr.junos.utils.scp import SCP
 
 def pyez_scp(
     task: Task,
+    direction: str,
     file: str,
     path: str,
     scpargs: Dict = {"progress": True},
 ) -> Result:
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
+
     with SCP(device, **scpargs) as scp:
-        scp.put(file, path)
-    return Result(host=task.host, result=f"Successfully copied")
+        if direction == "put":
+            # File: local file name - path: remote path
+            scp.put(file, path)
+        elif direction == "get":
+            # File: remote file name - path: local path
+            scp.get(file, path)
+        else:
+            raise ValueError("Direction must be either put or get")
+
+    return Result(
+        host=task.host, result=f"{direction.upper()} file operation successful"
+    )


### PR DESCRIPTION
The pyez_scp task plugin only supports the put operation and not getting a file **from** the device. An extra parameter has been added to the plugin and docs have been updated to reflect this.